### PR TITLE
Improve ID handling and sorting

### DIFF
--- a/app/features/music/CSVDataList.tsx
+++ b/app/features/music/CSVDataList.tsx
@@ -74,7 +74,6 @@ const getFieldAdjustedComponent = (
 const CSVDataList = (props: ICSVDataListProps): React.ReactElement => {
   const { songs, onSongChange, onColumnClick, sortColumns } = props;
 
-  // const items = getDummySongData();
   const items = songs;
 
   /*
@@ -100,36 +99,41 @@ const CSVDataList = (props: ICSVDataListProps): React.ReactElement => {
         : // Song data was loaded - use the columns from the file
           getColumnsFromObjectArray(items);
     // Adjust how columns render based on their data
-    return rawColumns.map((column) => {
-      const sortColumn = sortColumns?.find(
-        (c) => c.fieldName === column.fieldName
-      );
-      let isSorted;
-      let isSortedDescending;
-      if (typeof sortColumn !== 'undefined') {
-        isSorted = true;
-        isSortedDescending = sortColumn.direction === 'descending';
-      } else {
-        isSorted = undefined;
-        isSortedDescending = undefined;
-      }
-      return {
-        ...column,
-        onRender: (item: SongData) => {
-          return getFieldAdjustedComponent(
-            item,
-            {
-              name: column.fieldName,
-              dataType: column.data,
-            } as TypedProperty,
-            onSongChange
+    return (
+      rawColumns
+        .map((column) => {
+          const sortColumn = sortColumns?.find(
+            (c) => c.fieldName === column.fieldName
           );
-        },
-        onColumnClick,
-        isSorted,
-        isSortedDescending,
-      };
-    });
+          let isSorted;
+          let isSortedDescending;
+          if (typeof sortColumn !== 'undefined') {
+            isSorted = true;
+            isSortedDescending = sortColumn.direction === 'descending';
+          } else {
+            isSorted = undefined;
+            isSortedDescending = undefined;
+          }
+          return {
+            ...column,
+            onRender: (item: SongData) => {
+              return getFieldAdjustedComponent(
+                item,
+                {
+                  name: column.fieldName,
+                  dataType: column.data,
+                } as TypedProperty,
+                onSongChange
+              );
+            },
+            onColumnClick,
+            isSorted,
+            isSortedDescending,
+          };
+        })
+        // Hide the ID column
+        .filter((column) => column.fieldName !== songDataFields.ID.name)
+    );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [items.length, sortColumns]);
 

--- a/app/features/music/HeaderCommandBar.tsx
+++ b/app/features/music/HeaderCommandBar.tsx
@@ -14,6 +14,7 @@ import {
   resetSongsFromCached,
   saveFilePathSelector,
   songsSelector,
+  resetSortColumns,
 } from './musicSlice';
 import ConfirmDialog from '../../components/ConfirmDialog';
 import { saveCSVFile } from '../../utils/FileUtilities';
@@ -149,6 +150,7 @@ const HeaderCommandBar = (): React.ReactElement => {
         cancelAltText="No, go back!"
         onConfirm={() => {
           dispatch(resetSongsFromCached());
+          dispatch(resetSortColumns());
           addToast('Changes discarded', { appearance: 'info' });
         }}
       />

--- a/app/features/music/musicSlice.ts
+++ b/app/features/music/musicSlice.ts
@@ -34,21 +34,26 @@ const musicSlice = createSlice({
     toggleActive: (state, action: PayloadAction<SongData>) => {
       const targetSong = action.payload;
       state.songs = state.songs.map((s) =>
-        s.id === targetSong.id ? { ...s, active: !s.active } : s
+        s.new_file_name === targetSong.new_file_name
+          ? { ...s, active: !s.active }
+          : s
       );
     },
     updateSong: (state, action: PayloadAction<SongData>) => {
       const targetSong = action.payload;
       state.songs = state.songs.map((s) =>
-        s.id === targetSong.id ? targetSong : s
+        s.new_file_name === targetSong.new_file_name ? targetSong : s
       );
     },
     addSongs: (state, action: PayloadAction<SongData[]>) => {
-      const newSongs = action.payload;
+      const minId = Math.min(0, ...state.songs.map((s) => s.id));
+      const newSongs = action.payload.map((song, index) => ({
+        ...song,
+        id: minId - (action.payload.length - index),
+      }));
+
       // Add the new songs to state.songs and reassign ids
-      state.songs = [...newSongs, ...state.songs].map((song, index) => {
-        return { ...song, id: index + 1 };
-      });
+      state.songs = [...newSongs, ...state.songs];
     },
     resetSongsFromCached: (state) => {
       state.songs = state.cachedSongs;

--- a/app/features/music/musicSlice.ts
+++ b/app/features/music/musicSlice.ts
@@ -26,6 +26,8 @@ const musicSlice = createSlice({
       if (typeof songData !== 'undefined') {
         state.songs = songData;
         state.cachedSongs = songData;
+        // Reset sortColumns upon file load
+        state.sortColumns = [];
       }
     },
     cancelCSVLoad: (state) => {
@@ -81,8 +83,6 @@ const musicSlice = createSlice({
         state.sortColumns = state.sortColumns.filter((c) => c !== column);
       }
       // Apply the sorting rules to state.songs
-      // This may or may not work depending on how WriteableDrafts work
-      // TODO replace with local copy of state.sortColumns if it doesn't work
       state.songs = sortObjectListByFields(
         state.songs,
         state.sortColumns.length > 0

--- a/app/features/music/musicSlice.ts
+++ b/app/features/music/musicSlice.ts
@@ -91,6 +91,9 @@ const musicSlice = createSlice({
             [{ fieldName: 'id', direction: 'ascending' }]
       ) as SongData[];
     },
+    resetSortColumns: (state) => {
+      state.sortColumns = [];
+    },
   },
 });
 
@@ -106,6 +109,7 @@ export const {
   overwriteCachedSongs,
   setSaveFilePath,
   toggleSortColumn,
+  resetSortColumns,
 } = musicSlice.actions;
 
 /**


### PR DESCRIPTION
ID column is now hidden and IDs are not reassigned unless a new file is loaded. 
* Closes #38 
* Related to #33 (No ID reassign means that sorting can be accurately reset)

Sort columns are reset when a new file is loaded or when changes are discarded
* Related to #27 